### PR TITLE
terminal will stay on across pages

### DIFF
--- a/source/js/terminal.js
+++ b/source/js/terminal.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var infoBtn = document.getElementById('infoBtn');
   var infoBox = document.getElementById('infoBox');
   var closeBtn = document.getElementById('closeBtn');
-
+  
   if (infoBtn && infoBox && closeBtn) {
     infoBtn.addEventListener('click', function () {
       infoBox.style.display = 'block';
@@ -24,13 +24,27 @@ document.addEventListener('DOMContentLoaded', function () {
   const terminalContent = document.getElementById('terminal-content');
   const terminalClose = document.getElementById('terminal-close');
 
+
   if (terminal && terminalInput && terminalContent && terminalClose) {
-    function toggleTerminal() {
+    function toggleTerminal(forceState) {
       terminal.classList.toggle('hidden');
-      if (!terminal.classList.contains('hidden')) {
+      if (!terminal.classList.contains('hidden') || forceState === true) {
         terminalInput.focus();
+        // sets terminalState to open in localStorage so it saves across all pages
+        localStorage.setItem('terminalState', 'open');
+    
+      }
+      else {
+        // removes terminalState since it was toggled off so it will be toggled off across all pages
+        localStorage.removeItem('terminalState');
       }
     }
+
+  let terminalState = localStorage.getItem('terminalState');
+  // checks if terminal was perviously opened on another page and if so it toggled it on
+  if(terminalState == 'open') {
+    toggleTerminal(true);
+  }
 
     document.addEventListener('keydown', function (event) {
       if (event.ctrlKey && event.key === '/') {
@@ -39,10 +53,14 @@ document.addEventListener('DOMContentLoaded', function () {
       }
       if (!terminal.classList.contains('hidden') && event.key === 'q') {
         terminal.classList.add('hidden');
+        // toggles terminal off is q is pressed
+        localStorage.removeItem('terminalState');
       }
     });
     terminalClose.addEventListener('click', function () {
       terminal.classList.add('hidden');
+      // toggles terminal off if x is clicked
+      localStorage.removeItem('terminalState');
     });
     terminalInput.addEventListener('keydown', function (event) {
       if (event.key === 'Enter') {


### PR DESCRIPTION
#### Pull request for merging `terminal-fixes` into the `dev` branch

> Description

Fixing the terminal so that it stays on despite changing or reloading pages. This allows the user to not have to keep toggling the calendar on if they are going back and forth between pages.

> Changes Made

- Created `terminal-fixes` branch for this change
- In `terminal.js`, we added code that would save the terminalState to localStorage so that it would keep the same state despite changing pages
- We also removed this state from localStorage if the terminal was turned off with commands or with the close button so that it would stay the same on any page


> Testing

- Tests for the terminal are a work in progress and will be adjusted with these new changes

> Screenshots (if applicable)

N/A

> Checklist

Strict PR Policy:

- [x] All automated tests pass locally.
- [x] Manual testing has been performed according to the provided instructions.
- [x] Code follows the project's coding conventions and standards.
- [x] Documentation has been updated to reflect any relevant changes.
- [ ] This PR has been reviewed by at least 2 of the team members.
- [x] It passes all the appropriate Linters.
- [x] Make sure it passes Codacy quality checks.

> Additional Notes (if any)

Current end to end tests account for terminal closing if the pages switch, so these will have to be updated